### PR TITLE
ValueTransformer now supports null types, Dates, and Options

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -190,7 +190,7 @@ lazy val vegas = project.in(file("core")).
 
 lazy val spark = project.
   settings(moduleName := "vegas-spark").
-  dependsOn(vegas).
+  dependsOn(vegas % "compile->compile; test->test").
   settings(commonSettings: _*).
   settings(
     libraryDependencies ++= Seq(

--- a/core/src/main/scala/vegas/data/ValueTransformer.scala
+++ b/core/src/main/scala/vegas/data/ValueTransformer.scala
@@ -2,23 +2,31 @@ package vegas.data
 
 import java.text.SimpleDateFormat
 
+/**
+  * Base trait for transforming Any values into primitive types that are accepted by vega-lite. Default implementation
+  * does a pass through for primitives, converts dates to ISO8601, and uses toString for everything else.
+  */
 trait ValueTransformer {
 
-  def transform(values: Map[String, Any]): Map[String, Any] = values.map { case(k,v) => (k, transform(v)) }
+  def transform(values: Map[String, Any]): Map[String, Any] = values.map { case(k,v) => (k, transformValue(v)) }
 
   /**
     * Transforms Any values into one of the supported primitive types
     */
-  def transform(value: Any): Any
+  def transformValue(value: Any): Any
 
 }
 
 object DefaultValueTransformer extends ValueTransformer {
-  val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm");
+  val df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
-  def transform(v: Any) = v match {
+  def transformValue(v: Any): Any = v match {
+    case null => null
     case st if SimpleTypeUtils.isSimpleType(st) => st
+    case d: java.sql.Date => d.toString
     case d: java.util.Date => df.format(d)
+    case Some(x: Any) => transformValue(x)
+    case None => null
     case _ => v.toString
   }
 

--- a/core/src/test/scala/vegas/DSL/DataDSLSpec.scala
+++ b/core/src/test/scala/vegas/DSL/DataDSLSpec.scala
@@ -1,11 +1,10 @@
 package vegas.DSL
 
-import java.util.{Calendar, GregorianCalendar, TimeZone}
-
 import org.scalatest.{FlatSpec, Matchers}
 import vegas._
 import vegas.data.ValueTransformer
 import vegas.spec.Spec._
+import vegas.util.Time
 
 /**
   * @author Aish Fenton.
@@ -13,7 +12,7 @@ import vegas.spec.Spec._
 class DataDSLSpec extends FlatSpec with Matchers {
 
   case class Ex(a: Int, b: String)
-  val testValueTransformer = new ValueTransformer { def transform(v: Any) = "ok" }
+  val testValueTransformer = new ValueTransformer { def transformValue(v: Any) = "ok" }
 
 
   "DataDSL Trait" should "wire in data from Seq of Maps" in {
@@ -76,24 +75,13 @@ class DataDSLSpec extends FlatSpec with Matchers {
   }
 
   it should "transform values to 'SimpleTypes' that can be handled by vega-lite" in {
-
-    val refTimeZone = TimeZone.getTimeZone("PST")
-    val time = new GregorianCalendar(refTimeZone)
-    time.set(2015, Calendar.DECEMBER, 25, 0, 0, 0)
-
-    // Annoying but necessary to make sure timezones on different machines don't break
-    // the test.
-    val localOffset: Int = TimeZone.getDefault.getRawOffset
-    val refOffset: Int = refTimeZone.getRawOffset
-    time.add(Calendar.MILLISECOND, refOffset - localOffset)
-
-    val data = Seq(time.getTime, Ex(4, "a"), 3.14)
+    val data = Seq(Time.mkDate(2015, 12, 25), Ex(4, "a"), 3.14)
 
     val specBuilder = Vegas()
       .withValues(data)
 
     val expectedData = List(
-      Map("x" -> 0, "y" -> "2015-12-25T00:00"),
+      Map("x" -> 0, "y" -> "2015-12-25T00:00:00"),
       Map("x" -> 1, "y" -> "Ex(4,a)"),
       Map("x" -> 2, "y" -> 3.14)
     )

--- a/core/src/test/scala/vegas/data/ValueTransformerSpec.scala
+++ b/core/src/test/scala/vegas/data/ValueTransformerSpec.scala
@@ -1,0 +1,30 @@
+package vegas.data
+
+import org.scalatest.{FlatSpec, Matchers}
+import vegas.util.Time
+
+class ValueTransformerSpec extends FlatSpec with Matchers {
+
+  case class Test(i: Int)
+
+  "DefaultValueTransformer" should "transform any values to appropriate primitive types" in {
+    DefaultValueTransformer.transform(Map(
+      "a" -> 1,
+      "b" -> 3.14,
+      "c" -> null,
+      "d" -> Test(3),
+      "e" -> Some(3),
+      "f" -> None,
+      "g" -> Time.mkSqlTimestamp(1984, 12, 25, 23, 59, 59)
+    )) should === (Map(
+      "a" -> 1,
+      "b" -> 3.14,
+      "c" -> null,
+      "d" -> "Test(3)",
+      "e" -> 3,
+      "f" -> null,
+      "g" -> "1984-12-25T23:59:59"
+    ))
+  }
+
+}

--- a/core/src/test/scala/vegas/util/Time.scala
+++ b/core/src/test/scala/vegas/util/Time.scala
@@ -1,0 +1,41 @@
+package vegas.util
+
+import java.util.{Calendar, GregorianCalendar, TimeZone}
+
+/**
+  * Annoying but necessary (open to other suggestions though) utils for dealing with
+  * dates / times in Scala/Java
+  */
+object Time {
+
+  /**
+    * Makes a java.util.Date with the given year, month, day, and adjusts for local timezone.
+    * @param year The year (i.e. 2015)
+    * @param month The month number: 1-12 (i.e. 12 == December)
+    * @param day The day of the month: 1-31.
+    * @param hour The hour of the day (e.g. 23)
+    * @param minutes The minutes of the hour (e.g. 59)
+    * @param seconds The seconds of minute (e.g. 59)
+    * @param timeZone The timezone of given date (i.e. "PST"). Defaults to PST.
+    * @return A java.util Date object
+    */
+  def mkDate(year: Int, month: Int, day: Int, hour: Int = 0, minutes: Int = 0, seconds: Int = 0, timeZone: String = "PST"): java.util.Date = {
+    val refTimeZone = TimeZone.getTimeZone(timeZone)
+    val time = new GregorianCalendar(refTimeZone)
+    time.set(year, month - 1, day, hour, minutes, seconds)
+
+    // Annoying but necessary to make sure timezones on different machines don't break
+    // the test.
+    val localOffset: Int = TimeZone.getDefault.getRawOffset
+    val refOffset: Int = refTimeZone.getRawOffset
+    time.add(Calendar.MILLISECOND, refOffset - localOffset)
+
+    time.getTime
+  }
+
+  def mkSqlDate(year: Int, month: Int, day: Int, timeZone: String = "PST") = new java.sql.Date(mkDate(year, month, day, timeZone=timeZone).getTime)
+  def mkSqlTimestamp(year: Int, month: Int, day: Int, hour: Int, minutes: Int, seconds: Int,
+                     timeZone: String = "PST") = new java.sql.Timestamp(mkDate(year, month, day, hour, minutes, seconds, timeZone).getTime)
+
+
+}

--- a/spark/src/main/scala/vegas/sparkExt/package.scala
+++ b/spark/src/main/scala/vegas/sparkExt/package.scala
@@ -5,9 +5,11 @@ import vegas.DSL.DataDSL
 
 package object sparkExt {
 
+  val DefaultLimit = 10000
+
   implicit class VegasSpark[T](val specBuilder: DataDSL[T]) {
 
-    def withDataFrame(df: DataFrame, limit: Int = 1000): T = {
+    def withDataFrame(df: DataFrame, limit: Int = DefaultLimit): T = {
       val columns: Array[String] = df.columns
       val count: Double = df.count
       val data = {

--- a/spark/src/test/scala/vegas/sparkExt/SparkExtSpec.scala
+++ b/spark/src/test/scala/vegas/sparkExt/SparkExtSpec.scala
@@ -1,19 +1,25 @@
 package vegas.sparkExt
 
+import java.sql.Date
+
 import org.apache.spark.sql._
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StructField, StructType}
 import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import vegas._
-import vegas.sparkExt.SparkExtSpec.XYPair
+import vegas.sparkExt.SparkExtSpec._
 import vegas.spec.Spec.Data.Values
 
 /**
   * Created by DB Tsai on 10/17/16.
   */
 class SparkExtSpec extends FlatSpec with BeforeAndAfterAll with Matchers {
+  import vegas.util.Time._
+
   @transient var sparkSession: SparkSession = _
 
   var largeDataDF: DataFrame = _
   var smallDataDF: DataFrame = _
+  var complexDataDF: DataFrame = _
 
   override def beforeAll() {
     sparkSession = SparkSession.builder
@@ -23,8 +29,8 @@ class SparkExtSpec extends FlatSpec with BeforeAndAfterAll with Matchers {
       .getOrCreate()
 
     largeDataDF = sparkSession.sqlContext.createDataFrame(
-      sparkSession.sparkContext.parallelize((1 to 2000).map { i =>
-        val x = i / 2000.0
+      sparkSession.sparkContext.parallelize((1 to 20000).map { i =>
+        val x = i / 20000.0
         val y = 1.5 * x + 3
         XYPair(x, y)
       }))
@@ -36,6 +42,12 @@ class SparkExtSpec extends FlatSpec with BeforeAndAfterAll with Matchers {
         XYPair(x, y)
       }))
 
+    complexDataDF = sparkSession.sqlContext.createDataFrame(
+      sparkSession.sparkContext.parallelize(Seq(
+        Person("Bob", 35, None, Some(true), None, mkSqlTimestamp(1984, 12, 25, 23, 59, 0)),
+        Person("Alice", 12, Some(1.12), None, Some(mkSqlDate(2015, 12, 25)), mkSqlTimestamp(1984, 12, 25, 23, 59, 0))
+      )))
+
     super.beforeAll()
   }
 
@@ -44,13 +56,13 @@ class SparkExtSpec extends FlatSpec with BeforeAndAfterAll with Matchers {
     super.afterAll()
   }
 
-  "With large data as input, the result" should "be sampled to around 1k records" in {
+  "With large data as input, the result" should "be sampled to ~sparkExt.DefaultLimit number of records" in {
     val data = Vegas().withDataFrame(largeDataDF).spec.data.get.values.get
-    assert((data.size - 1000.0) / 1000 < 0.05, "data.size should be around 1k")
+    assert((data.size - sparkExt.DefaultLimit) / sparkExt.DefaultLimit < 0.05, "data.size should be around 1k")
 
-    data.foreach { case Values(point: Map[String, Double]) =>
-      val x = point.get("x").get
-      val y = point.get("y").get
+    data.foreach { case Values(point: Map[String, Double] @unchecked) =>
+      val x = point("x")
+      val y = point("y")
       y shouldEqual 1.5 * x + 3
     }
   }
@@ -59,17 +71,41 @@ class SparkExtSpec extends FlatSpec with BeforeAndAfterAll with Matchers {
     val data = Vegas().withDataFrame(smallDataDF).spec.data.get.values.get
     data.size shouldEqual 235
 
-    data.map { case Values(point: Map[String, Double]) =>
-      XYPair(point.get("x").get, point.get("y").get)
+    data.map { case Values(point: Map[String, Double] @unchecked) =>
+      XYPair(point("x"), point("y"))
     }.zip(1 to 235).foreach { case (pair, index) =>
       pair.x shouldEqual index / 235.0
       pair.y shouldEqual 1.5 * pair.x + 3
     }
   }
+
+  "Data with nulls" should "preserve them" in {
+    val nullDataDF = sparkSession.sqlContext.createDataFrame(
+      sparkSession.sparkContext.parallelize(Seq(Row(1, null), Row(null, 3.14))),
+      StructType( StructField("a", IntegerType, true) :: StructField("b", DoubleType, true) :: Nil )
+    )
+    val data = Vegas().withDataFrame(nullDataDF).spec.data.get.values.get
+
+    data.map { case Values(d: Map[String, Any] @unchecked) =>
+      (d("a"), d("b"))
+    } should === (Seq((1, null), (null, 3.14)))
+  }
+
+  "With complex data as input" should "encode it to the right types" in {
+    val data = Vegas().withDataFrame(complexDataDF).spec.data.get.values.get
+
+    data.map { case Values(d: Map[String, Any] @unchecked) =>
+      (d("name"), d("age"), d("height"), d("employee"), d("birthday"), d("createdAt"))
+    } should === (Seq(
+      ("Bob", 35L, null, true, null, "1984-12-25T23:59:00"),
+      ("Alice", 12L, 1.12, null, "2015-12-25", "1984-12-25T23:59:00")
+    ))
+  }
+
 }
 
 object SparkExtSpec {
-
   case class XYPair(x: Double, y: Double)
-
+  case class Person(name: String, age: Long, height: Option[Double], employee: Option[Boolean],
+                    birthday: Option[java.sql.Date], createdAt: java.sql.Timestamp)
 }


### PR DESCRIPTION
Part of fix for #76.

* ValueTransformer now supports null types, Sql Dates and Timestamps, and Options
* Added seconds to Date formatting (was missing before)
* Added Spark unit test with more complex data types 
* Changed default limit in Spark to 10,000