### PR TITLE
DSL Improvements

### DIFF
--- a/core/src/main/scala/vegas/DSL/SpecDSL.scala
+++ b/core/src/main/scala/vegas/DSL/SpecDSL.scala
@@ -4,6 +4,7 @@ import monocle.macros.GenLens
 import vegas.spec.Spec._
 import io.circe.Json
 import io.circe.syntax._
+import vegas.render.{ShowRender, StaticHTMLRenderer, WindowRenderer}
 
 object Vegas {
 
@@ -87,6 +88,22 @@ trait SpecBuilder {
     * Returns a Circe Json object that represents the spec. Also see [[toJson]]
     */
   def asCirceJson: Json
+
+}
+
+object SpecBuilder {
+
+  implicit class SpecBuilderRenderOps(val sb: SpecBuilder) extends AnyVal {
+
+    // directly show by having ShowRender guess which display mechanism is appropriate
+    def show(implicit showRender: ShowRender): Unit = showRender(sb)
+
+    // give a window rendered
+    def window: WindowRenderer = new WindowRenderer(sb.toJson)
+
+    // give an HTML renderer
+    def html: StaticHTMLRenderer = new StaticHTMLRenderer(sb.toJson)
+  }
 
 }
 

--- a/core/src/main/scala/vegas/render/BaseHTMLRenderer.scala
+++ b/core/src/main/scala/vegas/render/BaseHTMLRenderer.scala
@@ -26,6 +26,5 @@ trait BaseHTMLRenderer {
 
   def specJson: String
 
-  def show(implicit fn: String => Unit)
 
 }

--- a/core/src/main/scala/vegas/render/ShowRender.scala
+++ b/core/src/main/scala/vegas/render/ShowRender.scala
@@ -1,0 +1,20 @@
+package vegas.render
+
+import vegas.macros.ShowRenderMacros
+import scala.language.experimental.macros
+
+import vegas.DSL.SpecBuilder
+
+trait ShowRender extends (SpecBuilder => Unit)
+
+object ShowRender {
+  def using(f: SpecBuilder => Unit): ShowRender = new ShowRender {
+    def apply(sb: SpecBuilder) = f(sb)
+  }
+
+  implicit def default: ShowRender = macro ShowRenderMacros.materializeDefault
+}
+
+case class ShowHTML(output: String => Unit) extends ShowRender {
+  def apply(sb: SpecBuilder): Unit = output(StaticHTMLRenderer(sb.toJson).frameHTML())
+}

--- a/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
+++ b/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
@@ -68,13 +68,4 @@ case class StaticHTMLRenderer(specJson: String) extends BaseHTMLRenderer {
     """.stripMargin
     }
 
-  // Continence method
-  def show(implicit fn: String => Unit) = fn(frameHTML())
-
-}
-
-object StaticHTMLRenderer {
-
-  implicit def toStaticHTMLRenderer(sb: SpecBuilder): StaticHTMLRenderer = { new StaticHTMLRenderer(sb.toJson) }
-
 }

--- a/core/src/main/scala/vegas/render/WindowRenderer.scala
+++ b/core/src/main/scala/vegas/render/WindowRenderer.scala
@@ -73,12 +73,14 @@ case class WindowRenderer(specJson: String) {
 
   def close = onUIThread { window.close }
 
-  def show = Platform.runLater { window.load(specJson) }
+  def show = {
+    val _ = WindowRenderer.init
+    Platform.runLater { window.load(specJson) }
+  }
 
 }
 
 object WindowRenderer {
-  new JFXPanel()
-  implicit def toWindow(sb: SpecBuilder): WindowRenderer = { WindowRenderer(sb.toJson) }
+  lazy val init = new JFXPanel()
 }
 

--- a/core/src/test/scala/vegas/render/ShowSpec.scala
+++ b/core/src/test/scala/vegas/render/ShowSpec.scala
@@ -1,0 +1,94 @@
+package vegas.render
+
+import org.scalatest.{FlatSpec, Matchers}
+import vegas.DSL.SpecBuilder
+import vegas.{Bar, Nominal, Quantitative, Vegas}
+
+class ShowSpec extends FlatSpec with Matchers {
+  val data = Seq( Map("population" -> 318000000, "country" -> "USA"), Map("population" -> 64000000, "country" -> "UK") )
+
+  val specBuilder: SpecBuilder = Vegas("Country Pop")
+    .withData(data)
+    .addTransformCalculation("pop_millions", "datum.population / 1000000")
+    .encodeX("pop_millions", Quantitative)
+    .encodeY("country", Nominal)
+    .mark(Bar)
+
+  "show" should "use zeppelin when it's in scope" in {
+    var called: String = null
+    object org {
+      object apache {
+        object zeppelin {
+          object spark {
+            object utils {
+              object DisplayUtils {
+                def html(str: String) = {
+                  called = str
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    specBuilder.show
+    assert(called != null) // can't easily compare to an expected output due to random UUID
+  }
+
+  it should "use jupyter publish.html when it's in scope" in {
+    var called: String = null
+    object publish {
+      def html(str: String) = {
+        called = str
+      }
+    }
+    specBuilder.show
+    assert(called != null)
+  }
+
+  it should "use jupyter display.html when it's in scope" in {
+    var called: String = null
+    object display {
+      def html(str: String) = {
+        called = str
+      }
+    }
+    specBuilder.show
+    assert(called != null)
+  }
+
+  it should "use toree kernel.display.content when it's in scope" in {
+    var calledStr: String = null
+    var calledType: String = null
+    object kernel {
+      object display {
+        def content(typ: String, str: String) = {
+          calledStr = str
+          calledType = typ
+        }
+      }
+    }
+    specBuilder.show
+    assert(calledStr != null)
+    assert(calledType == "text/html")
+  }
+
+  it should "use window when nothing else is in scope" in {
+    var called: SpecBuilder = null
+    object vegas {
+      object render {
+        object ShowRender {
+          def using(fn: SpecBuilder => Unit) = {
+            new ShowRender {
+              def apply(sb: SpecBuilder) = {
+                called = sb
+              }
+            }
+          }
+        }
+      }
+    }
+    specBuilder.show
+    assert(called == specBuilder)
+  }
+}

--- a/core/src/test/scala/vegas/render/StaticHTMLRendererSpec.scala
+++ b/core/src/test/scala/vegas/render/StaticHTMLRendererSpec.scala
@@ -1,6 +1,7 @@
 package vegas.render
 
 import org.scalatest.{FlatSpec, Matchers}
+import vegas.DSL.SpecBuilder
 import vegas._
 
 class StaticHTMLRendererSpec extends FlatSpec with Matchers {
@@ -8,7 +9,7 @@ class StaticHTMLRendererSpec extends FlatSpec with Matchers {
 
   val data = Seq( Map("population" -> 318000000, "country" -> "USA"), Map("population" -> 64000000, "country" -> "UK") )
 
-  val specBuilder = Vegas("Country Pop")
+  val specBuilder: SpecBuilder = Vegas("Country Pop")
     .withData(data)
     .addTransformCalculation("pop_millions", "datum.population / 1000000")
     .encodeX("pop_millions", Quantitative)
@@ -16,7 +17,7 @@ class StaticHTMLRendererSpec extends FlatSpec with Matchers {
     .mark(Bar)
 
   "StaticHTMLRenderer.HTMLPage" should "produce an HTML page" in {
-    val html = specBuilder.pageHTML()
+    val html = specBuilder.html.pageHTML()
     html shouldBe a [String]
     html should startWith("<html>")
     html should include(specBuilder.toJson)
@@ -24,7 +25,7 @@ class StaticHTMLRendererSpec extends FlatSpec with Matchers {
   }
 
   "StaticHTMLRenderer.HTMLChart" should "produce a HTML script element containing the Spec json" in {
-    val html = specBuilder.plotHTML("test")
+    val html = specBuilder.html.plotHTML("test")
 
     html shouldBe a [String]
     html.trim should startWith ("<script>")
@@ -34,14 +35,14 @@ class StaticHTMLRendererSpec extends FlatSpec with Matchers {
 
   it should "use the given chart name" in {
     val name = "myChart"
-    val html = specBuilder.plotHTML(name)
+    val html = specBuilder.html.plotHTML(name)
 
     html should include ("embed(\"#" + name)
     html should include ("id='" + name)
   }
 
   it should "have a default chart name that starts with a letter, and contains no spaces" in {
-    val html = specBuilder.plotHTML()
+    val html = specBuilder.html.plotHTML()
     val name = "<div id='([^']*)'".r.findFirstMatchIn(html).get.group(1)
 
     name should fullyMatch regex """[a-zA-Z][a-zA-z\d-]*"""

--- a/core/src/test/scala/vegas/render/WindowRendererSpec.scala
+++ b/core/src/test/scala/vegas/render/WindowRendererSpec.scala
@@ -2,12 +2,13 @@ package vegas.render
 
 import vegas._
 import vegas.data.External._
-import org.scalatest.{ FlatSpec, Matchers }
+import org.scalatest.{FlatSpec, Matchers}
+import vegas.DSL.SpecBuilder
 
 class WindowRendererSpec extends FlatSpec with Matchers {
   import vegas.render.WindowRenderer._
 
-  val specBuilder =
+  val specBuilder: SpecBuilder =
     Vegas("Country Pop")
       .withURL(Population)
       .encodeX("age", Quant)
@@ -15,7 +16,7 @@ class WindowRendererSpec extends FlatSpec with Matchers {
       .mark(Bar)
 
   "WindowRenderer.show" should "render plots without JS errors" in {
-    val wr = WindowRenderer.toWindow(specBuilder)
+    val wr = specBuilder.window
     wr.show
     Thread.sleep(1000)
     wr.errors shouldBe (empty)

--- a/core/src/test/scala/vegas/util/WebGenerators.scala
+++ b/core/src/test/scala/vegas/util/WebGenerators.scala
@@ -16,7 +16,7 @@ trait WebGenerators {
     val writer = new FileWriter(file)
 
     val body = plots.map { plot =>
-      HTMLRenderer.toStaticHTMLRenderer(plot).frameHTML()
+      plot.html.frameHTML()
     }.mkString
 
     writer.write(s"""
@@ -33,7 +33,7 @@ trait WebGenerators {
     val file = File.createTempFile("vegas", ".html")
     val writer = new FileWriter(file)
 
-    val html = HTMLRenderer.toStaticHTMLRenderer(plot).pageHTML()
+    val html = plot.html.pageHTML()
     writer.write(html)
     writer.close
 

--- a/macros/src/main/scala/vegas/macros/ShowRenderMacros.scala
+++ b/macros/src/main/scala/vegas/macros/ShowRenderMacros.scala
@@ -1,0 +1,23 @@
+package vegas.macros
+
+import scala.reflect.macros.whitebox
+import scala.util.Try
+
+class ShowRenderMacros(val c: whitebox.Context) {
+  import c.universe.{Try => TryTree, _}
+
+  private def html(tree: Tree) = Try(c.typecheck(tree)).flatMap {
+    checked => Try(c.typecheck(q"vegas.render.ShowHTML($checked)"))
+  }
+
+  def materializeDefault: Tree = {
+    val possibilities: Try[Tree] =
+      html(q"""(str: String) => { org.apache.zeppelin.spark.utils.DisplayUtils.html(str) }""") orElse
+      html(q"""(str: String) => { publish.html(str) }""") orElse
+      html(q"""(str: String) => { display.html(str) }""") orElse
+      html(q"""(str: String) => { kernel.display.content("text/html", str) }""") orElse
+      Try(c.typecheck(q"""vegas.render.ShowRender.using(_.window.show)"""))
+
+    possibilities.getOrElse(c.abort(c.enclosingPosition, "No default Vegas renderer could be materialized"))
+  }
+}

--- a/spec/src/main/scala/vegas/spec/Spec.scala
+++ b/spec/src/main/scala/vegas/spec/Spec.scala
@@ -2,5 +2,5 @@ package vegas.spec
 
 import argus.macros._
 
-@fromSchemaResource("/vega-lite-schema.json", name="Vega", outPath=Some("/Users/afenton/Documents/netflix/src/Vegas/spec/target/scala-2.11/Spec.scala"))
-object Spec
+//@fromSchemaResource("/vega-lite-schema.json", name="Vega", outPath=Some("/Users/afenton/Documents/netflix/src/Vegas/spec/target/scala-2.11/Spec.scala"))
+//object Spec


### PR DESCRIPTION
* Replace implicit conversions with implicit ops class
* Introduce implicit class `ShowRender`
  * Macro guesses appropriate default `ShowRender` instance
  * Eliminates the need for import boilerplate in notebooks

I did this mainly because implicit views can often cause problems due to variance of the type arguments; making an invariant subtrait resolves that problem. Since we're already using macros, we can also go ahead and guess which of several common environments we're in (based on README) and build a default instance to the environment.