### PR TITLE
Use HTTPS for CDN

### DIFF
--- a/core/src/main/scala/vegas/render/BaseHTMLRenderer.scala
+++ b/core/src/main/scala/vegas/render/BaseHTMLRenderer.scala
@@ -11,7 +11,7 @@ trait BaseHTMLRenderer {
     .map { l => val row = l.split(","); (row(0), row(1)) }
     .toMap
 
-  private def CDN(artifact: String, file: String) = s"http://cdn.jsdelivr.net/webjars/org.webjars.bower/$artifact/${WebJars(artifact)}/$file"
+  private def CDN(artifact: String, file: String) = s"https://cdn.jsdelivr.net/webjars/org.webjars.bower/$artifact/${WebJars(artifact)}/$file"
 
   def JSImports = List(
     CDN("d3", "d3.min.js"),


### PR DESCRIPTION
Using HTTP breaks HTML for content served over HTTPS. The CDN supports HTTP/2, so it's faster to fetch from HTTPS anyway.

Another option is omitting the scheme and letting the browser resolve it, however this would break HTML served from `file://` with no real benefit.