### PR TITLE
Expose `Spec.SortOrderEnums.None` in DSL

### DIFF
--- a/core/src/main/scala/vegas/package.scala
+++ b/core/src/main/scala/vegas/package.scala
@@ -52,6 +52,7 @@ package object vegas {
     val Asc = Spec.SortOrderEnums.Ascending
     val Descending = Spec.SortOrderEnums.Descending
     val Desc = Spec.SortOrderEnums.Descending
+    val None = Spec.SortOrderEnums.None
   }
 
   val Category10 = "category10"


### PR DESCRIPTION
In plotting histograms as bar charts, you don't want the domain values sorted, but rendered in the order they were provided. Vega-Lite provides for this, but wasn't exposed fully in the Vegas DSL.