### PR TITLE
Fix macro for Zeppelin

### DIFF
--- a/core/src/test/scala/vegas/render/ShowSpec.scala
+++ b/core/src/test/scala/vegas/render/ShowSpec.scala
@@ -22,8 +22,9 @@ class ShowSpec extends FlatSpec with Matchers {
           object spark {
             object utils {
               object DisplayUtils {
-                def html(str: String) = {
+                def html(str: String): String = {
                   called = str
+                  s"%html $str"
                 }
               }
             }

--- a/macros/src/main/scala/vegas/macros/ShowRenderMacros.scala
+++ b/macros/src/main/scala/vegas/macros/ShowRenderMacros.scala
@@ -12,7 +12,7 @@ class ShowRenderMacros(val c: whitebox.Context) {
 
   def materializeDefault: Tree = {
     val possibilities: Try[Tree] =
-      html(q"""(str: String) => { org.apache.zeppelin.spark.utils.DisplayUtils.html(str) }""") orElse
+      html(q"""(str: String) => { println(org.apache.zeppelin.spark.utils.DisplayUtils.html(str)) }""") orElse
       html(q"""(str: String) => { publish.html(str) }""") orElse
       html(q"""(str: String) => { display.html(str) }""") orElse
       html(q"""(str: String) => { kernel.display.content("text/html", str) }""") orElse


### PR DESCRIPTION
- Fixes macro for Zeppelin (wrong type signature of DisplayUtils.html)
- Update docs to describe how ShowRender is used in manual cases