### PR TITLE
Fix notebooks (imports and ShowHTML)

### DIFF
--- a/core/src/test/scala/vegas/util/NotebookGenerator.scala
+++ b/core/src/test/scala/vegas/util/NotebookGenerator.scala
@@ -121,12 +121,11 @@ class ZeppelinGenerator extends NotebookGenerator {
   def preamble(version: String) =
     ("", s"""
      |%dep
-     |z.load("com.github.aishfenton:vegas-spark_2.11:${version}")""".stripMargin) ::
+     |z.load("org.vegas-viz:vegas-spark_2.11:${version}")""".stripMargin) ::
     ("", """
      |import vegas._
      |import vegas.data.External._
-     |import vegas.render.HTMLRenderer._
-     |implicit val displayer: String => Unit = (s) => println(s"%html $s")""".stripMargin) ::
+     |implicit val render = vegas.render.ShowHTML(s => print("%html " + s))""".stripMargin) ::
     Nil
 
   def mkNotebook(plots: List[(String, String)]) = {

--- a/core/src/test/scala/vegas/util/NotebookGenerator.scala
+++ b/core/src/test/scala/vegas/util/NotebookGenerator.scala
@@ -56,12 +56,11 @@ class JupyterGenerator extends NotebookGenerator {
     filterNot(_.isEmpty)
 
   def preamble(version: String) =
-    ("", s"""load.ivy("com.github.aishfenton" %% "vegas" % "$version")""") ::
+    ("", "import $ivy.`org.vegas-viz::vegas:" + s"$version`") ::
     ("", """
       |import vegas._
       |import vegas.data.External._
-      |import vegas.render.HTMLRenderer._
-      |implicit val displayer: String => Unit = display.html(_)""".stripMargin
+      |implicit val render = vegas.render.ShowHTML(publish.html(_))""".stripMargin
     ) ::
     Nil
 

--- a/notebooks/jupyter_example.ipynb
+++ b/notebooks/jupyter_example.ipynb
@@ -1,515 +1,282 @@
-{
- "cells": [
-  {
-   "cell_type": "code",
+
+ {
+   "cells": [ 
+ {
+   "cell_type" : "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
    "outputs": [],
-   "source": [
-    "import $ivy.`org.vegas-viz::vegas:0.3.6`\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "import vegas._\n",
-    "import vegas.data.External._\n",
-    "import vegas.render.HTMLRenderer._\n",
-    "implicit val displayer: String => Unit = publish.html(_)\n",
-    "\n",
-    "val Population = \"https://vega.github.io/vega-editor/app/data/population.json\"\n",
-    "val Cars = \"https://vega.github.io/vega-editor/app/data/cars.json\"\n",
-    "val Unemployment = \"https://vega.github.io/vega-editor/app/data/unemployment.json\"\n",
-    "val Movies = \"https://vega.github.io/vega-editor/app/data/movies.json\"\n",
-    "val Barley = \"https://vega.github.io/vega-editor/app/data/barley.json\"\n",
-    "val Stocks = \"https://vega.github.io/vega-editor/app/data/stocks.json\"\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# A simple bar chart with embedded data."
-   ]
-  },
-  {
-   "cell_type": "code",
+   "source": [ "import $ivy.`org.vegas-viz::vegas:0.3.8-SNAPSHOT`\n" ]
+ }
+    ,
+ {
+   "cell_type" : "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
    "outputs": [],
-   "source": [
-    "Vegas(\"A simple bar chart with embedded data.\").\n",
-    "  withData(Seq(\n",
-    "    Map(\"a\" -> \"A\", \"b\" -> 28), Map(\"a\" -> \"B\", \"b\" -> 55), Map(\"a\" -> \"C\", \"b\" -> 43),\n",
-    "    Map(\"a\" -> \"D\", \"b\" -> 91), Map(\"a\" -> \"E\", \"b\" -> 81), Map(\"a\" -> \"F\", \"b\" -> 53),\n",
-    "    Map(\"a\" -> \"G\", \"b\" -> 19), Map(\"a\" -> \"H\", \"b\" -> 87), Map(\"a\" -> \"I\", \"b\" -> 52)\n",
-    "  )).\n",
-    "  encodeX(\"a\", Ordinal).\n",
-    "  encodeY(\"b\", Quantitative).\n",
-    "  mark(Bar).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# A bar chart showing the US population distribution of age groups in 2000."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"A bar chart showing the US population distribution of age groups in 2000.\").\n",
-    "  withURL(Population).\n",
-    "  mark(Bar).\n",
-    "  filter(\"datum.year == 2000\").\n",
-    "  encodeY(\"age\", Ordinal, scale=Scale(bandSize=17)).\n",
-    "  encodeX(\"people\", Quantitative, aggregate=AggOps.Sum, axis=Axis(title=\"population\")).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas().\n",
-    "  withURL(Population).\n",
-    "  mark(Bar).\n",
-    "  addTransformCalculation(\"gender\", \"\"\"datum.sex == 2 ? \"Female\" : \"Male\"\"\"\").\n",
-    "  filter(\"datum.year == 2000\").\n",
-    "  encodeColumn(\"age\", Ord, scale=Scale(padding=4.0), axis=Axis(orient=Orient.Bottom, axisWidth=1.0, offset= -8.0)).\n",
-    "  encodeY(\"people\", Quantitative, aggregate=AggOps.Sum, axis=Axis(title=\"population\", grid=false)).\n",
-    "  encodeX(\"gender\", Nominal, scale=Scale(bandSize = 6.0), hideAxis=true).\n",
-    "  encodeColor(\"gender\", Nominal, scale=Scale(rangeNominals=List(\"#EA98D2\", \"#659CCA\"))).\n",
-    "  configFacet(cell=CellConfig(strokeWidth = 0)).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas().\n",
-    "  withURL(Unemployment).\n",
-    "  mark(Area).\n",
-    "  encodeX(\"date\", Temp, timeUnit=TimeUnit.Yearmonth, scale=Scale(nice=Nice.Month),\n",
-    "    axis=Axis(axisWidth=0, format=\"%Y\", labelAngle=0)).\n",
-    "  encodeY(\"count\", Quantitative, aggregate=AggOps.Sum).\n",
-    "  configCell(width=300, height=200).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas().\n",
-    "  withURL(Population).\n",
-    "  filter(\"datum.year == 2000\").\n",
-    "  addTransform(\"gender\", \"datum.sex == 2 ? \\\"Female\\\" : \\\"Male\\\"\").\n",
-    "  mark(Bar).\n",
-    "  encodeY(\"people\", Quant, AggOps.Sum, axis=Axis(title=\"population\")).\n",
-    "  encodeX(\"age\", Ord, scale=Scale(bandSize= 17)).\n",
-    "  encodeColor(\"gender\", Nominal, scale=Scale(rangeNominals=List(\"#EA98D2\", \"#659CCA\"))).\n",
-    "  configMark(stacked=StackOffset.Normalize).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
+   "source": [ "import vegas._\n","import vegas.data.External._\n","implicit val render = vegas.render.ShowHTML(publish.html(_))\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
    "metadata": {},
-   "source": [
-    "# A trellis scatterplot showing Horsepower and Miles per gallons, faceted by binned values of Acceleration."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"A trellis scatterplot showing Horsepower and Miles per gallons, faceted by binned values of Acceleration.\").\n",
-    "  withURL(Cars).\n",
-    "  mark(Point).\n",
-    "  encodeX(\"Horsepower\", Quantitative).\n",
-    "  encodeY(\"Miles_per_Gallon\", Quantitative).\n",
-    "  encodeRow(\"Acceleration\", Quantitative, enableBin=true).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas().\n",
-    "  withURL(Movies).\n",
-    "  mark(Point).\n",
-    "  encodeX(\"IMDB_Rating\", Quantitative, bin=Bin(maxbins=10.0)).\n",
-    "  encodeY(\"Rotten_Tomatoes_Rating\", Quantitative, bin=Bin(maxbins=10.0)).\n",
-    "  encodeSize(aggregate=AggOps.Count, field=\"*\", dataType=Quantitative).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas().\n",
-    "  withURL(Cars).\n",
-    "  mark(Point).\n",
-    "  encodeX(\"Horsepower\", Quantitative).\n",
-    "  encodeY(\"Miles_per_Gallon\", Quantitative).\n",
-    "  encodeColor(field=\"Origin\", dataType=Nominal).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# A scatterplot showing horsepower and miles per gallons with binned acceleration on color."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"A scatterplot showing horsepower and miles per gallons with binned acceleration on color.\").\n",
-    "  withURL(Cars).\n",
-    "  mark(Point).\n",
-    "  encodeX(\"Horsepower\", Quantitative).\n",
-    "  encodeY(\"Miles_per_Gallon\", Quantitative).\n",
-    "  encodeColor(field=\"Acceleration\", dataType=Quantitative, bin=Bin(maxbins=5.0)).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas().\n",
-    "  withURL(Cars).\n",
-    "  mark(Area).\n",
-    "  encodeX(\"Acceleration\", Quantitative, bin=Bin()).\n",
-    "  encodeY(\"Horsepower\", Quantitative, AggOps.Mean, enableBin=false).\n",
-    "  encodeColor(field=\"Cylinders\", dataType=Nominal).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# The Trellis display by Becker et al. helped establish small multiples as a “powerful mechanism for understanding interactions in studies of how a response depends on explanatory variables”. Here we reproduce a trellis of Barley yields from the 1930s, complete with main-effects ordering to facilitate comparison."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"The Trellis display by Becker et al. helped establish small multiples as a “powerful mechanism for understanding interactions in studies of how a response depends on explanatory variables”. Here we reproduce a trellis of Barley yields from the 1930s, complete with main-effects ordering to facilitate comparison.\").\n",
-    "  withURL(Barley).\n",
-    "  mark(Point).\n",
-    "  encodeRow(\"site\", Ordinal).\n",
-    "  encodeX(\"yield\", Quantitative, aggregate=AggOps.Mean).\n",
-    "  encodeY(\"variety\", Ordinal, sortField=Sort(\"yield\", AggOps.Mean), scale=Scale(bandSize = 12.0)).\n",
-    "  encodeColor(field=\"year\", dataType=Nominal).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# A scatterplot with custom star shapes."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"A scatterplot with custom star shapes.\").\n",
-    "  withURL(Cars).\n",
-    "  mark(Point).\n",
-    "  encodeX(\"Horsepower\", Quant).\n",
-    "  encodeY(\"Miles_per_Gallon\", Quant).\n",
-    "  encodeColor(\"Cylinders\", Nom).\n",
-    "  encodeSize(\"Weight_in_lbs\", Quant).\n",
-    "  configMark(customShape=\"M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z\").\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# A scatterplot showing average horsepower and displacement for cars from different origins."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"A scatterplot showing average horsepower and displacement for cars from different origins.\").\n",
-    "  withURL(Cars).\n",
-    "  mark(Point).\n",
-    "  encodeX(\"Horsepower\", Quant, AggOps.Mean).\n",
-    "  encodeY(\"Displacement\", Quant, AggOps.Mean).\n",
-    "  encodeDetail(\"Origin\").\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Stock prices of 5 Tech Companies Over Time."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"Stock prices of 5 Tech Companies Over Time.\").\n",
-    "  withURL(Stocks, formatType = DataFormat.Csv).\n",
-    "  mark(Line).\n",
-    "  encodeX(\"date\", Temp).\n",
-    "  encodeY(\"price\", Quant).\n",
-    "  encodeDetailFields(Field(field=\"symbol\", dataType=Nominal)).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Plot with hard-coded size value"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"Plot with hard-coded size value\").\n",
-    "  withURL(Cars).\n",
-    "  mark(Circle).\n",
-    "  encodeY(\"Horsepower\", Quantitative).\n",
-    "  encodeX(\"Miles_per_Gallon\", Quantitative).\n",
-    "  encodeSize(value=201L).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Plots both mean and IQR as a background layer"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas.layered(\"Plots both mean and IQR as a background layer\").\n",
-    "  withURL(Population).\n",
-    "  withLayers(\n",
-    "    Layer().\n",
-    "      mark(Line).\n",
-    "      encodeX(\"age\", Ordinal).\n",
-    "      encodeY(\"people\", aggregate=AggOps.Mean),\n",
-    "    Layer().\n",
-    "      mark(Area).\n",
-    "      encodeX(\"age\", Ordinal).\n",
-    "      encodeY(\"people\", aggregate=AggOps.Q1).\n",
-    "      encodeY2(\"people\", aggregate=AggOps.Q3)\n",
-    "  ).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Plot with legend on the left and a different title "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"Plot with legend on the left and a different title \").\n",
-    "  withURL(Cars).\n",
-    "  mark(Point).\n",
-    "  encodeY(\"Horsepower\", Quantitative).\n",
-    "  encodeX(\"Miles_per_Gallon\", Quantitative).\n",
-    "  encodeColor(field=\"Origin\", dataType=Nominal, legend=Legend(orient = \"left\", title=\"Place of Origin\" )).\n",
-    "  encodeShape(field=\"Origin\", dataType=Nominal, legend=Legend(orient = \"left\", title=\"Place of Origin\",\n",
-    "    titleColor=\"red\")).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Plot to show Binning options"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"Plot to show Binning options\").\n",
-    "  withURL(Movies).\n",
-    "  mark(Bar).\n",
-    "  encodeX(\"IMDB_Rating\", Quantitative, bin=Bin(step=2.0, maxbins=3.0)).\n",
-    "  encodeY(field=\"*\", Quantitative, aggregate=AggOps.Count).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Plot to show Binning options"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"Plot to show Binning options\").\n",
-    "  withURL(Movies).\n",
-    "  mark(Bar).\n",
-    "  encodeX(\"Worldwide_Gross\", Quant, bin=Bin(maxbins=20.0), sortOrder=SortOrder.Desc).\n",
-    "  encodeY(field=\"*\", Quant, aggregate=AggOps.Count).\n",
-    "  show\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Plot to show usage of encodeText"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "Vegas(\"Plot to show usage of encodeText\").\n",
-    "  withURL(Cars).\n",
-    "  addTransform(\"OriginInitial\", \"datum.Origin[0]\").\n",
-    "  mark(Text).\n",
-    "  encodeX(\"Horsepower\", Quantitative).\n",
-    "  encodeY(\"Miles_per_Gallon\", Quantitative).\n",
-    "  encodeColor(field=\"Origin\", dataType= Nominal).\n",
-    "  encodeText(field=\"OriginInitial\", dataType= Nominal).\n",
-    "  show\n"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Scala",
-   "language": "scala",
-   "name": "scala"
-  },
-  "language_info": {
-   "codemirror_mode": "text/x-scala",
-   "file_extension": ".scala",
-   "mimetype": "text/x-scala",
-   "name": "scala211",
-   "nbconvert_exporter": "scala",
-   "pygments_lexer": "scala",
-   "version": "2.11.8"
-  }
+   "source": [ "# A simple bar chart with embedded data." ]
  },
- "nbformat": 4,
- "nbformat_minor": 0
-}
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"A simple bar chart with embedded data.\").\n","  withData(Seq(\n","    Map(\"a\" -> \"A\", \"b\" -> 28), Map(\"a\" -> \"B\", \"b\" -> 55), Map(\"a\" -> \"C\", \"b\" -> 43),\n","    Map(\"a\" -> \"D\", \"b\" -> 91), Map(\"a\" -> \"E\", \"b\" -> 81), Map(\"a\" -> \"F\", \"b\" -> 53),\n","    Map(\"a\" -> \"G\", \"b\" -> 19), Map(\"a\" -> \"H\", \"b\" -> 87), Map(\"a\" -> \"I\", \"b\" -> 52)\n","  )).\n","  encodeX(\"a\", Ordinal).\n","  encodeY(\"b\", Quantitative).\n","  mark(Bar).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# A bar chart showing the US population distribution of age groups in 2000." ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"A bar chart showing the US population distribution of age groups in 2000.\").\n","  withURL(Population).\n","  mark(Bar).\n","  filter(\"datum.year == 2000\").\n","  encodeY(\"age\", Ordinal, scale=Scale(bandSize=17)).\n","  encodeX(\"people\", Quantitative, aggregate=AggOps.Sum, axis=Axis(title=\"population\")).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas().\n","  withURL(Population).\n","  mark(Bar).\n","  addTransformCalculation(\"gender\", \"\"\"datum.sex == 2 ? \"Female\" : \"Male\"\"\"\").\n","  filter(\"datum.year == 2000\").\n","  encodeColumn(\"age\", Ord, scale=Scale(padding=4.0), axis=Axis(orient=Orient.Bottom, axisWidth=1.0, offset= -8.0)).\n","  encodeY(\"people\", Quantitative, aggregate=AggOps.Sum, axis=Axis(title=\"population\", grid=false)).\n","  encodeX(\"gender\", Nominal, scale=Scale(bandSize = 6.0), hideAxis=true).\n","  encodeColor(\"gender\", Nominal, scale=Scale(rangeNominals=List(\"#EA98D2\", \"#659CCA\"))).\n","  configFacet(cell=CellConfig(strokeWidth = 0)).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas().\n","  withURL(Unemployment).\n","  mark(Area).\n","  encodeX(\"date\", Temp, timeUnit=TimeUnit.Yearmonth, scale=Scale(nice=Nice.Month),\n","    axis=Axis(axisWidth=0, format=\"%Y\", labelAngle=0)).\n","  encodeY(\"count\", Quantitative, aggregate=AggOps.Sum).\n","  configCell(width=300, height=200).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas().\n","  withURL(Population).\n","  filter(\"datum.year == 2000\").\n","  addTransform(\"gender\", \"datum.sex == 2 ? \\\"Female\\\" : \\\"Male\\\"\").\n","  mark(Bar).\n","  encodeY(\"people\", Quant, AggOps.Sum, axis=Axis(title=\"population\")).\n","  encodeX(\"age\", Ord, scale=Scale(bandSize= 17)).\n","  encodeColor(\"gender\", Nominal, scale=Scale(rangeNominals=List(\"#EA98D2\", \"#659CCA\"))).\n","  configMark(stacked=StackOffset.Normalize).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# A trellis scatterplot showing Horsepower and Miles per gallons, faceted by binned values of Acceleration." ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"A trellis scatterplot showing Horsepower and Miles per gallons, faceted by binned values of Acceleration.\").\n","  withURL(Cars).\n","  mark(Point).\n","  encodeX(\"Horsepower\", Quantitative).\n","  encodeY(\"Miles_per_Gallon\", Quantitative).\n","  encodeRow(\"Acceleration\", Quantitative, enableBin=true).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas().\n","  withURL(Movies).\n","  mark(Point).\n","  encodeX(\"IMDB_Rating\", Quantitative, bin=Bin(maxbins=10.0)).\n","  encodeY(\"Rotten_Tomatoes_Rating\", Quantitative, bin=Bin(maxbins=10.0)).\n","  encodeSize(aggregate=AggOps.Count, field=\"*\", dataType=Quantitative).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas().\n","  withURL(Cars).\n","  mark(Point).\n","  encodeX(\"Horsepower\", Quantitative).\n","  encodeY(\"Miles_per_Gallon\", Quantitative).\n","  encodeColor(field=\"Origin\", dataType=Nominal).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# A scatterplot showing horsepower and miles per gallons with binned acceleration on color." ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"A scatterplot showing horsepower and miles per gallons with binned acceleration on color.\").\n","  withURL(Cars).\n","  mark(Point).\n","  encodeX(\"Horsepower\", Quantitative).\n","  encodeY(\"Miles_per_Gallon\", Quantitative).\n","  encodeColor(field=\"Acceleration\", dataType=Quantitative, bin=Bin(maxbins=5.0)).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas().\n","  withURL(Cars).\n","  mark(Area).\n","  encodeX(\"Acceleration\", Quantitative, bin=Bin()).\n","  encodeY(\"Horsepower\", Quantitative, AggOps.Mean, enableBin=false).\n","  encodeColor(field=\"Cylinders\", dataType=Nominal).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# The Trellis display by Becker et al. helped establish small multiples as a “powerful mechanism for understanding interactions in studies of how a response depends on explanatory variables”. Here we reproduce a trellis of Barley yields from the 1930s, complete with main-effects ordering to facilitate comparison." ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"The Trellis display by Becker et al. helped establish small multiples as a “powerful mechanism for understanding interactions in studies of how a response depends on explanatory variables”. Here we reproduce a trellis of Barley yields from the 1930s, complete with main-effects ordering to facilitate comparison.\").\n","  withURL(Barley).\n","  mark(Point).\n","  encodeRow(\"site\", Ordinal).\n","  encodeX(\"yield\", Quantitative, aggregate=AggOps.Mean).\n","  encodeY(\"variety\", Ordinal, sortField=Sort(\"yield\", AggOps.Mean), scale=Scale(bandSize = 12.0)).\n","  encodeColor(field=\"year\", dataType=Nominal).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# A scatterplot with custom star shapes." ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"A scatterplot with custom star shapes.\").\n","  withURL(Cars).\n","  mark(Point).\n","  encodeX(\"Horsepower\", Quant).\n","  encodeY(\"Miles_per_Gallon\", Quant).\n","  encodeColor(\"Cylinders\", Nom).\n","  encodeSize(\"Weight_in_lbs\", Quant).\n","  configMark(customShape=\"M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z\").\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# A scatterplot showing average horsepower and displacement for cars from different origins." ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"A scatterplot showing average horsepower and displacement for cars from different origins.\").\n","  withURL(Cars).\n","  mark(Point).\n","  encodeX(\"Horsepower\", Quant, AggOps.Mean).\n","  encodeY(\"Displacement\", Quant, AggOps.Mean).\n","  encodeDetail(\"Origin\").\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# Stock prices of 5 Tech Companies Over Time." ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"Stock prices of 5 Tech Companies Over Time.\").\n","  withURL(Stocks, formatType = DataFormat.Csv).\n","  mark(Line).\n","  encodeX(\"date\", Temp).\n","  encodeY(\"price\", Quant).\n","  encodeDetailFields(Field(field=\"symbol\", dataType=Nominal)).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# Plot with hard-coded size value" ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"Plot with hard-coded size value\").\n","  withURL(Cars).\n","  mark(Circle).\n","  encodeY(\"Horsepower\", Quantitative).\n","  encodeX(\"Miles_per_Gallon\", Quantitative).\n","  encodeSize(value=201L).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# Plots both mean and IQR as a background layer" ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas.layered(\"Plots both mean and IQR as a background layer\").\n","  withURL(Population).\n","  withLayers(\n","    Layer().\n","      mark(Line).\n","      encodeX(\"age\", Ordinal).\n","      encodeY(\"people\", aggregate=AggOps.Mean),\n","    Layer().\n","      mark(Area).\n","      encodeX(\"age\", Ordinal).\n","      encodeY(\"people\", aggregate=AggOps.Q1).\n","      encodeY2(\"people\", aggregate=AggOps.Q3)\n","  ).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# Plot with legend on the left and a different title " ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"Plot with legend on the left and a different title \").\n","  withURL(Cars).\n","  mark(Point).\n","  encodeY(\"Horsepower\", Quantitative).\n","  encodeX(\"Miles_per_Gallon\", Quantitative).\n","  encodeColor(field=\"Origin\", dataType=Nominal, legend=Legend(orient = \"left\", title=\"Place of Origin\" )).\n","  encodeShape(field=\"Origin\", dataType=Nominal, legend=Legend(orient = \"left\", title=\"Place of Origin\",\n","    titleColor=\"red\")).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# Plot to show Binning options" ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"Plot to show Binning options\").\n","  withURL(Movies).\n","  mark(Bar).\n","  encodeX(\"IMDB_Rating\", Quantitative, bin=Bin(step=2.0, maxbins=3.0)).\n","  encodeY(field=\"*\", Quantitative, aggregate=AggOps.Count).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# Plot to show Binning options" ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"Plot to show Binning options\").\n","  withURL(Movies).\n","  mark(Bar).\n","  encodeX(\"Worldwide_Gross\", Quant, bin=Bin(maxbins=20.0), sortOrder=SortOrder.Desc).\n","  encodeY(field=\"*\", Quant, aggregate=AggOps.Count).\n","  show\n" ]
+ }
+    ,
+ {
+   "cell_type" : "markdown",
+   "metadata": {},
+   "source": [ "# Plot to show usage of encodeText" ]
+ },
+      
+ {
+   "cell_type" : "code",
+   "execution_count": null,
+   "outputs": [],
+   "metadata": {},
+   "source": [ "Vegas(\"Plot to show usage of encodeText\").\n","  withURL(Cars).\n","  addTransform(\"OriginInitial\", \"datum.Origin[0]\").\n","  mark(Text).\n","  encodeX(\"Horsepower\", Quantitative).\n","  encodeY(\"Miles_per_Gallon\", Quantitative).\n","  encodeColor(field=\"Origin\", dataType= Nominal).\n","  encodeText(field=\"OriginInitial\", dataType= Nominal).\n","  show\n" ]
+ }
+     ],
+   "metadata": {
+     "kernelspec": {
+       "display_name": "Scala 2.11",
+       "language": "scala211",
+       "name": "scala211"
+     },
+     "language_info": {
+       "codemirror_mode": "text/x-scala",
+       "file_extension": ".scala",
+       "mimetype": "text/x-scala",
+       "name": "scala211",
+       "pygments_lexer": "scala",
+       "version": "2.11.6"
+     }
+   },
+   "nbformat": 4,
+   "nbformat_minor": 0
+ }
+    

--- a/notebooks/zeppelin_example.json
+++ b/notebooks/zeppelin_example.json
@@ -6,13 +6,13 @@
  {
    "config": { "title": false },
    "title": "",
-   "text": "\n%dep\nz.load(\"com.github.aishfenton:vegas-spark_2.11:0.3.6\")"
+   "text": "\n%dep\nz.load(\"org.vegas-viz:vegas-spark_2.11:0.3.8-SNAPSHOT\")"
  }
     ,
  {
    "config": { "title": false },
    "title": "",
-   "text": "\nimport vegas._\nimport vegas.data.External._\nimport vegas.render.HTMLRenderer._\nimplicit val displayer: String => Unit = (s) => println(s\"%html $s\")"
+   "text": "\nimport vegas._\nimport vegas.data.External._\nimplicit val render = vegas.render.ShowHTML(s => print(\"%html \" + s))"
  }
     ,
  {


### PR DESCRIPTION
Fixing Jupyter and Zeppelin NotebookGenerator with the two changes:
1.  Change artifact groupId from ``com.github.aishfenton`` to ``org.vegas-viz``
2.  Update the ``implicit val render`` to the newly added ``vegas.render.ShowHTML``

Note that @izhangzhihao had earlier fixed the jupyter notebook without adjusting the NotebookGenerator. Hence, you will see more diffs in the jupyter_example.ipynb. 