### PR TITLE
Remove implicit val renderer from generated notebooks

### DIFF
--- a/core/src/test/scala/vegas/util/NotebookGenerator.scala
+++ b/core/src/test/scala/vegas/util/NotebookGenerator.scala
@@ -59,8 +59,7 @@ class JupyterGenerator extends NotebookGenerator {
     ("", "import $ivy.`org.vegas-viz::vegas:" + s"$version`") ::
     ("", """
       |import vegas._
-      |import vegas.data.External._
-      |implicit val render = vegas.render.ShowHTML(publish.html(_))""".stripMargin
+      |import vegas.data.External._""".stripMargin
     ) ::
     Nil
 
@@ -123,8 +122,7 @@ class ZeppelinGenerator extends NotebookGenerator {
      |z.load("org.vegas-viz:vegas-spark_2.11:${version}")""".stripMargin) ::
     ("", """
      |import vegas._
-     |import vegas.data.External._
-     |implicit val render = vegas.render.ShowHTML(s => print("%html " + s))""".stripMargin) ::
+     |import vegas.data.External._""".stripMargin) ::
     Nil
 
   def mkNotebook(plots: List[(String, String)]) = {

--- a/notebooks/jupyter_example.ipynb
+++ b/notebooks/jupyter_example.ipynb
@@ -14,7 +14,7 @@
    "execution_count": null,
    "outputs": [],
    "metadata": {},
-   "source": [ "import vegas._\n","import vegas.data.External._\n","implicit val render = vegas.render.ShowHTML(publish.html(_))\n" ]
+   "source": [ "import vegas._\n","import vegas.data.External._\n" ]
  }
     ,
  {

--- a/notebooks/zeppelin_example.json
+++ b/notebooks/zeppelin_example.json
@@ -12,7 +12,7 @@
  {
    "config": { "title": false },
    "title": "",
-   "text": "\nimport vegas._\nimport vegas.data.External._\nimplicit val render = vegas.render.ShowHTML(s => print(\"%html \" + s))"
+   "text": "\nimport vegas._\nimport vegas.data.External._"
  }
     ,
  {


### PR DESCRIPTION
After Jeremy's fixes below, the implicit renderer variable is no longer required:
https://github.com/vegas-viz/Vegas/pull/86
https://github.com/vegas-viz/Vegas/pull/99

Hence, taking it off in the NotebookGenerator.
