### PR TITLE
Remove all use of jQuery, wrap invocation in IIFE

### DIFF
--- a/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
+++ b/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
@@ -59,7 +59,7 @@ case class StaticHTMLRenderer(specJson: String) extends BaseHTMLRenderer {
       |    (function() {
       |      function resizeIFrame(el, k) {
       |        var height = el.contentWindow.document.body.scrollHeight || '400'; // Fallback in case of no scroll height
-      |        el.style.height = el.contentWindow.document.body.scrollHeight + 'px';
+      |        el.style.height = height + 'px';
       |        if (k <= 10) { setTimeout(function() { resizeIFrame(el, k+1) }, 1000 + (k * 250)) };
       |      }
       |      resizeIFrame(document.querySelector('#${frameName}'), 1);

--- a/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
+++ b/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
@@ -56,15 +56,14 @@ case class StaticHTMLRenderer(specJson: String) extends BaseHTMLRenderer {
     s"""
       |  <iframe id="${frameName}" sandbox="allow-scripts allow-same-origin" style="border: none; width: 100%" srcdoc="${xml.Utility.escape(pageHTML(name))}"></iframe>
       |  <script>
-      |    if (typeof resizeIFrame != 'function') {
+      |    (function() {
       |      function resizeIFrame(el, k) {
-      |        $$(el.contentWindow.document).ready(function() {
-      |          el.style.height = el.contentWindow.document.body.scrollHeight + 'px';
-      |        });
+      |        var height = el.contentWindow.document.body.scrollHeight || '400'; // Fallback in case of no scroll height
+      |        el.style.height = el.contentWindow.document.body.scrollHeight + 'px';
       |        if (k <= 10) { setTimeout(function() { resizeIFrame(el, k+1) }, 1000 + (k * 250)) };
       |      }
-      |    }
-      |    $$().ready( function() { resizeIFrame($$('#${frameName}').get(0), 1); });
+      |      resizeIFrame(document.querySelector('#${frameName}'), 1);
+      |    })(); // IIFE
       |  </script>
     """.stripMargin
     }


### PR DESCRIPTION
This fixes some issues folks were having when there were multiple vegas plots on one page while also making a non-jquery way of plotting.

* The function declaration is done in an [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression) so nothing else overwrites the function declaration
* `document.querySelector` is used instead of `$()`
* since the output here is done _well_ after the document is ready, I've removed the jquery `onReady`

If people like this change, I'll update for the tests too.