### PR TITLE
disable showing of vega actions

### DIFF
--- a/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
+++ b/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
@@ -24,6 +24,7 @@ case class StaticHTMLRenderer(specJson: String) extends BaseHTMLRenderer {
   def plotHTML(name: String = this.defaultName) =
     s"""
        | <div id='$name'></div>
+       | <style>{".vega-actions{ display: none; }"}</style>
        | <script>
        |   var embedSpec = {
        |     mode: "vega-lite",


### PR DESCRIPTION
The vega actions may not be usable in all frontends that display it, so I'm disabling it by making it not show.

Note: this is also what we do in nteract with the vega mimetype: https://github.com/nteract/nteract/blob/76493806330373bce633c7c904b9e6fdcdbba59e/packages/transform-vega/src/index.js#L85

xref: https://github.com/jupyter-scala/jupyter-scala/pull/175#issuecomment-341217710