### PR TITLE
Enable publishing core + macros for 2.12

### DIFF
--- a/core/src/test/scala/vegas/WebMatchers.scala
+++ b/core/src/test/scala/vegas/WebMatchers.scala
@@ -4,13 +4,13 @@ import org.openqa.selenium.chrome.ChromeDriver
 import org.openqa.selenium.logging.LogType
 import java.util.logging.Level
 
-import org.scalatest.ShouldMatchers
+import org.scalatest.Matchers
 import vegas.util.WebGenerators
 
 import scala.collection.JavaConverters._
 
 trait WebMatchers extends WebGenerators {
-  self: ShouldMatchers =>
+  self: Matchers =>
 
   def hasNoJsErrors()(implicit webDriver: ChromeDriver) = {
     val logs = webDriver.manage.logs.get(LogType.BROWSER).filter(Level.WARNING).asScala.toList

--- a/core/src/test/scala/vegas/integration/PlotHtml.scala
+++ b/core/src/test/scala/vegas/integration/PlotHtml.scala
@@ -3,10 +3,10 @@ package vegas.integration
 import org.openqa.selenium.WebDriver
 import vegas.WebMatchers
 import vegas.fixtures.{BasicPlots, VegasPlots}
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, ShouldMatchers}
+import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
 import org.scalatest.selenium.Chrome
 
-class PlotHtml extends FlatSpec with ShouldMatchers with WebMatchers with Chrome with BeforeAndAfterAll {
+class PlotHtml extends FlatSpec with Matchers with WebMatchers with Chrome with BeforeAndAfterAll {
 
   val scheme = "file://"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version = 0.13.10
+sbt.version = 1.1.0
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
 logLevel := Level.Warn
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.6")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.7")


### PR DESCRIPTION
- bumps sbt version to 1.1.0. 
- adds explicit dep on scala-xml, which was preventing a build on 2.12 (and also a [weird bug](https://issues.scala-lang.org/browse/SI-8358) in the scala compiler ). 
- bumps various library versions. enables cross-compile of base vegas module on 2.12.