### PR TITLE
Disable body margin of user agent stylesheet

### DIFF
--- a/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
+++ b/core/src/main/scala/vegas/render/StaticHTMLRenderer.scala
@@ -18,7 +18,7 @@ case class StaticHTMLRenderer(specJson: String) extends BaseHTMLRenderer {
        |  <head>
        |    ${ importsHTML(additionalImports:_*) }
        |  </head>
-       |  <body>
+       |  <body style="margin: 0px;">
     """.stripMargin
 
   def plotHTML(name: String = this.defaultName) =


### PR DESCRIPTION
When I tried the [example notebook](http://nbviewer.jupyter.org/github/aishfenton/Vegas/blob/master/notebooks/jupyter_example.ipynb) with [jupyter-scala](https://github.com/jupyter-scala/jupyter-scala) (on Chromium browser v64.0.3282.140), I 
have noticed that the user agent stylesheet increases the height of the content in iframe and then a scroll bar appears.

In order to disable body margin of user agent stylesheet, I added `margin: 0px;` to `<body>` tag.

### Before
![image](https://user-images.githubusercontent.com/10720090/36602248-e68be5e6-18fa-11e8-9dd6-11fcb0bf8908.png)

### After
![image](https://user-images.githubusercontent.com/10720090/36602255-ebb6e3a4-18fa-11e8-90f1-b73dafd976a8.png)