### PR TITLE
Refactor fixtures.{Basic,Vegas}Plots.scala

### DIFF
--- a/core/src/test/scala/vegas/DSL/AllDSLSpec.scala
+++ b/core/src/test/scala/vegas/DSL/AllDSLSpec.scala
@@ -3,8 +3,8 @@ package vegas.DSL
 import java.io.File
 
 import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.Inspectors.forAll
 import vegas.JsonMatchers
+import vegas.fixtures.BasicPlots.plotsWithNames
 
 import scala.io.Source
 
@@ -12,16 +12,14 @@ class AllDSLSpec extends FlatSpec with Matchers with JsonMatchers {
   import AllDSLSpec._
 
   behavior of "BasicPlots"
-  for((fileName, plot) <- testCases) {
-    it should s"produce the correct json as ${fileName}" in {
-      plot.asCirceJson should beSameJsonAs(examples(fileName))
+  for((name, plot) <- plotsWithNames) {
+    it should s"produce the correct json as ${name}" in {
+      plot.asCirceJson should beSameJsonAs(examples(name))
     }
   }
 }
 
 object AllDSLSpec {
-  import vegas.fixtures.BasicPlots._
-
   val examples = new File("core/src/test/resources/example-specs")
     .listFiles.toList
     .filter(_.getName.endsWith("json"))
@@ -33,27 +31,4 @@ object AllDSLSpec {
       (file.getName.stripSuffix(".vl.json"), json)
     }
     .toMap
-
-  val testCases = List(
-    "bar" -> SimpleBarChart,
-    "bar_aggregate" -> AggregateBarChart,
-    "bar_grouped" -> GroupedBarChart,
-    "area" -> AreaChart,
-    "stacked_bar_normalize" -> NormalizedStackedBarChart,
-    "scatter_binned" -> ScatterBinnedPlot,
-    "scatter_color" -> ScatterColorPlot,
-    "scatter_binned_color" -> ScatterBinnedColorPlot,
-    "stacked_area_binned" -> StackedAreaBinnedPlot,
-    "trellis_barley" -> SortColorPlot,
-    "trellis_scatter_binned_row" -> BinnedChart,
-    "scatter_shape_custom" -> CustomShapePlot,
-    "line_detail" -> LineDetail,
-    "github_punchcard" -> GithubPunchCard,
-    "trellis_anscombe" -> AnscombesQuartet,
-    "stacked_area" -> StackedAreaChart,
-    "stacked_area_normalize" -> NormalizedStackedAreaChart,
-    "stacked_area_stream" -> Streamgraph,
-    "stacked_bar_weather" -> StackedBarChart,
-    "tick_strip" -> StripPlot
-  ).sortBy(_._1)
 }

--- a/core/src/test/scala/vegas/fixtures/BasicPlots.scala
+++ b/core/src/test/scala/vegas/fixtures/BasicPlots.scala
@@ -208,10 +208,30 @@ object BasicPlots {
       encodeX("Horsepower", Quantitative).
       encodeY("Cylinders", Ordinal)
 
-  val plots: List[SpecBuilder] = SimpleBarChart :: AggregateBarChart :: GroupedBarChart :: AreaChart ::
-    NormalizedStackedBarChart :: BinnedChart :: ScatterBinnedPlot :: ScatterColorPlot :: ScatterBinnedColorPlot ::
-    StackedAreaBinnedPlot :: SortColorPlot :: CustomShapePlot :: ScatterAggregateDetail :: LineDetail ::
-    GithubPunchCard :: AnscombesQuartet :: StackedAreaChart :: NormalizedStackedAreaChart :: Streamgraph ::
-    StackedBarChart :: StripPlot :: Nil
+  // Names (ex. bar, bar_aggregate, etc.) are corresponding to filenames
+  //  of `/core/src/test/resources/example-specs/*.vl.json`
+  val plotsWithNames: List[(String, SpecBuilder)] = List(
+    "bar" -> SimpleBarChart,
+    "bar_aggregate" -> AggregateBarChart,
+    "bar_grouped" -> GroupedBarChart,
+    "area" -> AreaChart,
+    "stacked_bar_normalize" -> NormalizedStackedBarChart,
+    "scatter_binned" -> ScatterBinnedPlot,
+    "scatter_color" -> ScatterColorPlot,
+    "scatter_binned_color" -> ScatterBinnedColorPlot,
+    "stacked_area_binned" -> StackedAreaBinnedPlot,
+    "trellis_barley" -> SortColorPlot,
+    "trellis_scatter_binned_row" -> BinnedChart,
+    "scatter_shape_custom" -> CustomShapePlot,
+    "line_detail" -> LineDetail,
+    "github_punchcard" -> GithubPunchCard,
+    "trellis_anscombe" -> AnscombesQuartet,
+    "stacked_area" -> StackedAreaChart,
+    "stacked_area_normalize" -> NormalizedStackedAreaChart,
+    "stacked_area_stream" -> Streamgraph,
+    "stacked_bar_weather" -> StackedBarChart,
+    "tick_strip" -> StripPlot
+  ).sortBy(_._1)
 
+  val plots: List[SpecBuilder] = plotsWithNames.map(_._2)
 }

--- a/core/src/test/scala/vegas/fixtures/VegasPlots.scala
+++ b/core/src/test/scala/vegas/fixtures/VegasPlots.scala
@@ -63,7 +63,14 @@ object VegasPlots {
     encodeColor(field="Origin", dataType= Nominal).
     encodeText(field="OriginInitial", dataType= Nominal)
 
-  val plots: List[SpecBuilder] = ValuePlot :: IQRPlot :: LegendPlot :: BinnedPlot :: BinnedPlotWithSort :: ColoredTextScatterPlot ::Nil
+  val plotsWithNames: List[(String, SpecBuilder)] = List(
+    "value_plot" -> ValuePlot,
+    "iqr_plot" -> IQRPlot,
+    "legend_plot" -> LegendPlot,
+    "binned plot" -> BinnedPlot,
+    "binned_plot_with_sort" -> BinnedPlotWithSort,
+    "colored_txt_scatter_plot" -> ColoredTextScatterPlot
+  ).sortBy(_._1)
 
+  val plots: List[SpecBuilder] = plotsWithNames.map(_._2)
 }
-

--- a/core/src/test/scala/vegas/integration/PlotHtml.scala
+++ b/core/src/test/scala/vegas/integration/PlotHtml.scala
@@ -10,19 +10,18 @@ class PlotHtml extends FlatSpec with Matchers with WebMatchers with Chrome with 
 
   val scheme = "file://"
 
-  "Basic plots" should "render HTML without error" in {
-
-    BasicPlots.plots.foreach { plot =>
+  behavior of "Basic plots"
+  BasicPlots.plotsWithNames.foreach { case (name, plot) =>
+    it should s"render HTML without error ${name}" in {
       go to (scheme + mkPage(plot))
       find(tagName("canvas"))
       hasNoJsErrors()
     }
-
   }
 
-  "Vegas plots" should "render HTML without error" in {
-
-    VegasPlots.plots.foreach { plot =>
+  behavior of "Vegas plots"
+  VegasPlots.plotsWithNames.foreach { case (name, plot) =>
+    it should s"render HTML without error ${name}" in {
       go to (scheme + mkPage(plot))
       find(tagName("canvas"))
       hasNoJsErrors()


### PR DESCRIPTION
It devides test cases (`Basic plots should render HTML without error` and `Vegas plots should render HTML without error`) into plots.

### Before
```
[info] PlotHtml:
[info] Basic plots
[info] - should render HTML without error (3 seconds, 28 milliseconds)
[info] Vegas plots
[info] - should render HTML without error (470 milliseconds)
[info] Run completed in 5 seconds, 113 milliseconds.
```

### After

```
[info] PlotHtml:
[info] Basic plots
[info] - should render HTML without error area (366 milliseconds)
[info] - should render HTML without error bar (160 milliseconds)
[info] - should render HTML without error bar_aggregate (37 milliseconds)
[info] - should render HTML without error bar_grouped (40 milliseconds)
[info] - should render HTML without error github_punchcard (39 milliseconds)
[info] - should render HTML without error line_detail (37 milliseconds)
[info] - should render HTML without error scatter_binned (34 milliseconds)
[info] - should render HTML without error scatter_binned_color (38 milliseconds)
[info] - should render HTML without error scatter_color (33 milliseconds)
[info] - should render HTML without error scatter_shape_custom (35 milliseconds)
[info] - should render HTML without error stacked_area (520 milliseconds)
[info] - should render HTML without error stacked_area_binned (107 milliseconds)
[info] - should render HTML without error stacked_area_normalize (498 milliseconds)
[info] - should render HTML without error stacked_area_stream (500 milliseconds)
[info] - should render HTML without error stacked_bar_normalize (62 milliseconds)
[info] - should render HTML without error stacked_bar_weather (34 milliseconds)
[info] - should render HTML without error tick_strip (67 milliseconds)
[info] - should render HTML without error trellis_anscombe (51 milliseconds)
[info] - should render HTML without error trellis_barley (90 milliseconds)
[info] - should render HTML without error trellis_scatter_binned_row (107 milliseconds)
[info] Vegas plots
[info] - should render HTML without error binned plot (33 milliseconds)
[info] - should render HTML without error binned_plot_with_sort (34 milliseconds)
[info] - should render HTML without error colored_txt_scatter_plot (73 milliseconds)
[info] - should render HTML without error iqr_plot (71 milliseconds)
[info] - should render HTML without error legend_plot (70 milliseconds)
[info] - should render HTML without error value_plot (61 milliseconds)
[info] Run completed in 4 seconds, 812 milliseconds.
```