### PR TITLE
Fix deprecated warnings on build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -142,8 +142,8 @@ lazy val commonSettings = Seq(
 )
 
 lazy val noPublishSettings = Seq(
-  publish := (),
-  publishLocal := (),
+  publish := {},
+  publishLocal := {},
   publishArtifact := false
 )
 


### PR DESCRIPTION
```
/home/travis/build/vegas-viz/Vegas/build.sbt:145: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
        signature: DefinableTask.:=(v: S): sbt.Def.Setting[sbt.Task[S]]
  given arguments: <none>
 after adaptation: DefinableTask.:=((): Unit)
  publish := ()
          ^
/home/travis/build/vegas-viz/Vegas/build.sbt:146: warning: Adaptation of argument list by inserting () is deprecated: this is unlikely to be what you want.
        signature: DefinableTask.:=(v: S): sbt.Def.Setting[sbt.Task[S]]
  given arguments: <none>
 after adaptation: DefinableTask.:=((): Unit)
  publishLocal := ()

```
https://travis-ci.org/vegas-viz/Vegas/jobs/402833152#L790-L801