### PR TITLE
Suppress Spark's `INFO` logs at test time

### DIFF
--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -1,0 +1,1 @@
+log4j.logger.org.apache.spark=WARN


### PR DESCRIPTION
Suppress Spark's INFO logs because they are verbose.

before: https://travis-ci.org/vegas-viz/Vegas/jobs/439251181#L1058-L1441
after: https://travis-ci.org/vegas-viz/Vegas/jobs/445184508#L1047-L1048