### PR TITLE
Ignore Spec.scala when calculating coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "core/src/main/scala/vegas/spec/Spec.scala"


### PR DESCRIPTION
Ignore Spec.scala because it is automatically generated from jsonschema.

<https://docs.codecov.io/docs/ignoring-paths>